### PR TITLE
Preserve master database path case

### DIFF
--- a/umalauncher/mdb.py
+++ b/umalauncher/mdb.py
@@ -40,9 +40,9 @@ def get_db_path():
 
 def _get_db_fingerprint():
     """Return the stable identity used to invalidate master-data caches."""
-    db_path = os.path.normcase(os.path.realpath(os.path.abspath(get_db_path())))
+    db_path = os.path.realpath(os.path.abspath(get_db_path()))
     stat = os.stat(db_path)
-    return db_path, stat.st_mtime_ns, stat.st_size
+    return os.path.normcase(db_path), stat.st_mtime_ns, stat.st_size
 
 
 def update_mdb_cache(force=False):


### PR DESCRIPTION
## Summary

- stat the resolved `master.mdb` path before applying case normalization
- retain a normalized path identity for cache fingerprint comparisons

## Root cause

The cache fingerprint implementation applied `os.path.normcase()` before `os.stat()`. On a Windows profile path with case-sensitive directory handling, that lowercased a valid mixed-case path and made it unresolvable.

## Impact

This restores the prior database-access behavior for affected installations without changing the existing database locations or cache invalidation semantics.

## Validation

- `python -m unittest discover -s tests -v` (7 passed)
- `python -m compileall -q umalauncher scripts tests`
- `python scripts/check_public_boundary.py`
- `git diff --check`